### PR TITLE
[bitnami/elasticsearch] POC: ES to be compatible with Istio

### DIFF
--- a/bitnami/elasticsearch/Chart.yaml
+++ b/bitnami/elasticsearch/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: elasticsearch
-version: 11.0.18
+version: 12.0.0
 appVersion: 7.6.2
 description: A highly scalable open-source full-text search and analytics engine
 keywords:

--- a/bitnami/elasticsearch/README.md
+++ b/bitnami/elasticsearch/README.md
@@ -106,7 +106,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `clusterDomain`                                   | Kubernetes cluster domain                                                                                                                                 | `cluster.local`                                              |
 | `discovery.name`                                  | Discover node pod name                                                                                                                                    | `discovery`                                                  |
 | `coordinating.replicas`                           | Desired number of Elasticsearch coordinating-only nodes                                                                                                   | `2`                                                          |
-| `coordinating.updateStrategy.type`                | Update strategy for Coordinating Deployment                                                                                                               | `RollingUpdate`                                              |
+| `coordinating.updateStrategy.type`                | Update strategy for Coordinating Statefulset                                                                                                               | `RollingUpdate`                                              |
 | `coordinating.heapSize`                           | Coordinating-only node heap size                                                                                                                          | `128m`                                                       |
 | `coordinating.podAnnotations`                     | Annotations for coordniating pods.                                                                                                                        | `{}`                                                         |
 | `coordinating.service.type`                       | Kubernetes Service type (coordinating-only nodes)                                                                                                         | `ClusterIP`                                                  |
@@ -164,6 +164,7 @@ The following table lists the configurable parameters of the Elasticsearch chart
 | `ingest.enabled`                                  | Enable ingest nodes                                                                                                                                       | `false`                                                      |
 | `ingest.name`                                     | Ingest node pod name                                                                                                                                      | `ingest`                                                     |
 | `ingest.replicas`                                 | Desired number of Elasticsearch ingest nodes                                                                                                              | `2`                                                          |
+| `ingest.updateStrategy.type`                      | Update strategy for Ingest Statefulset                                                                                                                    | `RollingUpdate`                                              |
 | `ingest.heapSize`                                 | Ingest node heap size                                                                                                                                     | `128m`                                                       |
 | `ingest.service.type`                             | Kubernetes Service type (ingest nodes)                                                                                                                    | `ClusterIP`                                                  |
 | `ingest.service.port`                             | Kubernetes Service port Elasticsearch transport port (ingest nodes)                                                                                       | `9300`                                                       |
@@ -478,6 +479,15 @@ As an alternative, this chart supports using an initContainer to change the owne
 You can enable this initContainer by setting `volumePermissions.enabled` to `true`.
 
 ## Notable changes
+
+### 12.0.0
+
+Several changes were introduced that breaks backwards compatibilty:
+
+- Data & Ingest nodes now use a statefulset instead of a deployment.
+- Headless services are added to provide a stable network identifier to each Elasticsearch node.
+- Ports names were prefixed with the protocol to comply with Istio (see https://istio.io/docs/ops/deployment/requirements/).
+- Labels are adapted to follow the Helm charts best practices.
 
 ### 11.0.0
 

--- a/bitnami/elasticsearch/templates/_helpers.tpl
+++ b/bitnami/elasticsearch/templates/_helpers.tpl
@@ -135,24 +135,37 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
-Return the hostname of every ElasticSearch node
+Return the hostname of every ElasticSearch master-eligible node
+*/}}
+{{- define "elasticsearch.masterHosts" -}}
+{{- $clusterDomain := .Values.clusterDomain }}
+{{- $releaseNamespace := .Release.Namespace }}
+{{- $masterReplicaCount := int .Values.master.replicas }}
+{{- $masterFullname := include "elasticsearch.master.fullname" . }}
+{{- range $e, $i := until $masterReplicaCount }}
+{{- $masterFullname }}-{{ $i }}.{{ $masterFullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
+{{- end -}}
+{{- end -}}
+
+{{/*
+Return the hostname of every ElasticSearch seed node
 */}}
 {{- define "elasticsearch.hosts" -}}
 {{- $clusterDomain := .Values.clusterDomain }}
 {{- $releaseNamespace := .Release.Namespace }}
-{{- $coordinatingReplicaCount := int .Values.coordinating.replicas }}
-{{- $coordinatingFullname := include "elasticsearch.coordinating.fullname" . }}
 {{- $masterReplicaCount := int .Values.master.replicas }}
 {{- $masterFullname := include "elasticsearch.master.fullname" . }}
+{{- $coordinatingReplicaCount := int .Values.coordinating.replicas }}
+{{- $coordinatingFullname := include "elasticsearch.coordinating.fullname" . }}
 {{- $dataReplicaCount := int .Values.data.replicas }}
 {{- $dataFullname := include "elasticsearch.data.fullname" . }}
 {{- $ingestReplicaCount := int .Values.ingest.replicas }}
 {{- $ingestFullname := include "elasticsearch.ingest.fullname" . }}
-{{- range $e, $i := until $coordinatingReplicaCount }}
-{{- $coordinatingFullname }}-{{ $i }}.{{ $coordinatingFullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
-{{- end -}}
 {{- range $e, $i := until $masterReplicaCount }}
 {{- $masterFullname }}-{{ $i }}.{{ $masterFullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
+{{- end -}}
+{{- range $e, $i := until $coordinatingReplicaCount }}
+{{- $coordinatingFullname }}-{{ $i }}.{{ $coordinatingFullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},
 {{- end -}}
 {{- range $e, $i := until $dataReplicaCount }}
 {{- $dataFullname }}-{{ $i }}.{{ $dataFullname }}-headless.{{ $releaseNamespace }}.svc.{{ $clusterDomain }},

--- a/bitnami/elasticsearch/templates/configmap-curator.yaml
+++ b/bitnami/elasticsearch/templates/configmap-curator.yaml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "elasticsearch.curator.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: curator
+    app.kubernetes.io/component: curator
 data:
   action_file.yml: {{ required "A valid .Values.curator.configMaps.action_file_yml entry is required!" (toYaml .Values.curator.configMaps.action_file_yml | indent 2) }}
   config.yml: {{ required "A valid .Values.curator.configMaps.config_yml entry is required!" (tpl (toYaml .Values.curator.configMaps.config_yml | indent 2) $) }}

--- a/bitnami/elasticsearch/templates/coordinating-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-headless-svc.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: http
       port: 9200

--- a/bitnami/elasticsearch/templates/coordinating-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-headless-svc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch.coordinating.fullname" . }}-headless
+  labels: {{- include "elasticsearch.labels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinating-only
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+    - name: tcp-transport
+      port: 9300
+      targetPort: transport
+  selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: coordinating-only

--- a/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
@@ -1,23 +1,31 @@
-apiVersion: {{ template "deployment.apiVersion" . }}
-kind: Deployment
+apiVersion: {{ template "statefulset.apiVersion" . }}
+kind: StatefulSet
 metadata:
   name: {{ include "elasticsearch.coordinating.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: coordinating-only
+    app.kubernetes.io/component: coordinating-only
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: coordinating-only
 spec:
-  strategy:
+  updateStrategy:
     type: {{ .Values.coordinating.updateStrategy.type }}
-    {{- if (eq "Recreate" .Values.coordinating.updateStrategy.type) }}
+    {{- if (eq "OnDelete" .Values.coordinating.updateStrategy.type) }}
     rollingUpdate: null
+    {{- else if .Values.coordinating.updateStrategy.rollingUpdatePartition }}
+    rollingUpdate:
+      partition: {{ .Values.coordinating.updateStrategy.rollingUpdatePartition }}
     {{- end }}
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: coordinating-only
+      app.kubernetes.io/component: coordinating-only
   replicas: {{ .Values.coordinating.replicas }}
+  serviceName: {{ include "elasticsearch.coordinating.fullname" . }}-headless
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}
-        role: coordinating-only
+        app.kubernetes.io/component: coordinating-only
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: coordinating-only
       {{- with .Values.coordinating.podAnnotations }}
       annotations: {{- toYaml . | nindent 10 }}
       {{- end }}
@@ -66,7 +74,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
-              value: {{ template "elasticsearch.discovery.fullname" . }}
+              value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
       app.kubernetes.io/component: coordinating-only
   replicas: {{ .Values.coordinating.replicas }}
   serviceName: {{ include "elasticsearch.coordinating.fullname" . }}-headless
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}

--- a/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-statefulset.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
+            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
+              value: {{ include "elasticsearch.masterHosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}

--- a/bitnami/elasticsearch/templates/coordinating-svc.yaml
+++ b/bitnami/elasticsearch/templates/coordinating-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "elasticsearch.coordinating.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: coordinating-only
+    app.kubernetes.io/component: coordinating-only
   annotations: {{ include "elasticsearch.tplValue" ( dict "value" .Values.coordinating.service.annotations "context" $) | nindent 4 }}
 spec:
   type: {{ .Values.coordinating.service.type | quote }}
@@ -20,4 +20,4 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
-    role: coordinating-only
+    app.kubernetes.io/component: coordinating-only

--- a/bitnami/elasticsearch/templates/cronjob.yaml
+++ b/bitnami/elasticsearch/templates/cronjob.yaml
@@ -4,7 +4,9 @@ kind: CronJob
 metadata:
   name: {{ template "elasticsearch.curator.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: curator
+    app.kubernetes.io/component: curator
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: curator
   {{- if .Values.curator.cronjob.annotations }}
   annotations: {{- toYaml .Values.curator.cronjob.annotations | nindent 4 }}
   {{- end }}
@@ -21,15 +23,17 @@ spec:
   {{- end }}
   jobTemplate:
     metadata:
-      labels:
-        app: {{ template "elasticsearch.name" . }}
-        release: {{ .Release.Name | quote }}
+      labels: {{- include "elasticsearch.labels" . | nindent 8 }}
+        app.kubernetes.io/component: curator
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: curator
     spec:
       template:
         metadata:
-          labels:
-            app: {{ template "elasticsearch.name" . }}
-            release: {{ .Release.Name | quote }}
+          labels: {{- include "elasticsearch.labels" . | nindent 12 }}
+            app.kubernetes.io/component: curator
+            ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+            app: curator
           {{- if .Values.curator.podAnnotations }}
           annotations: {{- toYaml .Values.curator.podAnnotations | nindent 12 }}
           {{- end }}

--- a/bitnami/elasticsearch/templates/data-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/data-headless-svc.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: tcp-transport
       port: 9300

--- a/bitnami/elasticsearch/templates/data-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/data-headless-svc.yaml
@@ -1,17 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "elasticsearch.discovery.fullname" . }}
+  name: {{ include "elasticsearch.data.fullname" . }}-headless
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+    app.kubernetes.io/component: data
 spec:
   type: ClusterIP
   clusterIP: None
   ports:
-    - port: 9300
-      name: transport
+    - name: tcp-transport
+      port: 9300
       targetPort: transport
-  publishNotReadyAddresses: true
-  sessionAffinity: None
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: data

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -93,6 +93,8 @@ spec:
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
+            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
+              value: {{ include "elasticsearch.masterHosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -3,7 +3,9 @@ kind: StatefulSet
 metadata:
   name: {{ include "elasticsearch.data.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: data
+    app.kubernetes.io/component: data
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: data
 spec:
   updateStrategy:
     type: {{ .Values.data.updateStrategy.type }}
@@ -15,13 +17,15 @@ spec:
     {{- end }}
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: data
-  serviceName: {{ include "elasticsearch.data.fullname" . }}
+      app.kubernetes.io/component: data
+  serviceName: {{ include "elasticsearch.data.fullname" . }}-headless
   replicas: {{ .Values.data.replicas }}
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}
-        role: data
+        app.kubernetes.io/component: data
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: data
       {{- with .Values.data.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -90,7 +94,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
-              value: {{ template "elasticsearch.discovery.fullname" . }}
+              value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/data-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/data-statefulset.yaml
@@ -19,6 +19,7 @@ spec:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: data
   serviceName: {{ include "elasticsearch.data.fullname" . }}-headless
+  podManagementPolicy: Parallel
   replicas: {{ .Values.data.replicas }}
   template:
     metadata:

--- a/bitnami/elasticsearch/templates/hooks/job.install.yaml
+++ b/bitnami/elasticsearch/templates/hooks/job.install.yaml
@@ -6,66 +6,60 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: {{ template "elasticsearch.curator.fullname" . }}-curator-on-{{ $kind }}
-  labels:
-    app: {{ template "elasticsearch.name" . }}
-    chart: {{ template "elasticsearch.chart" . }}
-    heritage: {{ .Release.Service | quote }}
-    release: {{ .Release.Name | quote }}
-    role: "curator"
+  labels: {{- include "elasticsearch.labels" . | nindent 4 }}
+    app.kubernetes.io/component: curator
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: curator
   annotations:
     "helm.sh/hook": post-{{ $kind }}
     "helm.sh/hook-weight": "1"
-{{- if $.Values.cronjob.annotations }}
-{{ toYaml $.Values.cronjob.annotations | indent 4 }}
-{{- end }}
+    {{- if $.Values.cronjob.annotations }}
+    {{- toYaml $.Values.cronjob.annotations | nindent 4 }}
+    {{- end }}
 spec:
  template:
     metadata:
-      labels:
-        app: {{ template "elasticsearch.name" . }}
-        release: {{ .Release.Name | quote }}
-{{- if $.Values.podAnnotations }}
-      annotations:
-{{ toYaml $.Values.podAnnotations | indent 8 }}
-{{- end }}
+      labels: {{- include "elasticsearch.labels" . | nindent 10 }}
+        app.kubernetes.io/component: curator
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: curator
+      {{- if $.Values.podAnnotations }}
+      annotations: {{- toYaml $.Values.podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
-      volumes:
-        - name: config-volume
-          configMap:
-            name: {{ template "elasticsearch.curator.fullname" . }}
-{{- if $.Values.curator.extraVolumes }}
-{{ toYaml $.Values.curator.extraVolumes | indent 8 }}
-{{- end }}
       restartPolicy: Never
-{{- if $.Values.curator.priorityClassName }}
-      priorityClassName: "{{ $.Values.curator.priorityClassName }}"
-{{- end }}
+      {{- if $.Values.curator.priorityClassName }}
+      priorityClassName: {{ $.Values.curator.priorityClassName | quote }}
+      {{- end }}
+      {{- if $.Values.curator.affinity }}
+      affinity: {{- include "elasticsearch.tplValue" (dict "value" $.Values.curator.affinity "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.curator.nodeSelector }}
+      nodeSelector: {{- include "elasticsearch.tplValue" (dict "value" $.Values.curator.nodeSelector "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if $.Values.curator.tolerations }}
+      tolerations: {{- include "elasticsearch.tplValue" (dict "value" $.Values.curator.tolerations "context" $) | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ template "elasticsearch.curator.fullname" . }}
           image: {{ template "elasticsearch.curator.image" . }}
           imagePullPolicy: {{ .Values.curator.image.pullPolicy | quote }}
+          command: [ "curator" ]
+          args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
+          resources: {{- toYaml $.Values.curator.resources | nindent 12 }}
           volumeMounts:
             - name: config-volume
               mountPath: /etc/es-curator
-    {{- if $.Values.curator.extraVolumeMounts }}
-{{ toYaml $.Values.curator.extraVolumeMounts | indent 12 }}
-    {{- end }}
-          command: [ "curator" ]
-          args: [ "--config", "/etc/es-curator/config.yml", "/etc/es-curator/action_file.yml" ]
-          resources:
-{{ toYaml $.Values.curator.resources | indent 12 }}
-    {{- with $.Values.curator.nodeSelector }}
-      nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with $.Values.curator.affinity }}
-      affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with $.Values.curator.tolerations }}
-      tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- end -}}
+           {{- if $.Values.curator.extraVolumeMounts }}
+           {{- toYaml $.Values.curator.extraVolumeMounts | nindent 12 }}
+           {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "elasticsearch.curator.fullname" . }}
+        {{- if $.Values.curator.extraVolumes }}
+        {{- toYaml $.Values.curator.extraVolumes | nindent 8 }}
+        {{- end }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/bitnami/elasticsearch/templates/ingest-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/ingest-headless-svc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.ingest.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch.ingest.fullname" . }}-headless
+  labels: {{- include "elasticsearch.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingest
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-transport
+      port: 9300
+      targetPort: transport
+  selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: ingest
+{{- end }}

--- a/bitnami/elasticsearch/templates/ingest-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/ingest-headless-svc.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: tcp-transport
       port: 9300

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -21,6 +21,7 @@ spec:
       app.kubernetes.io/component: ingest
   replicas: {{ .Values.ingest.replicas }}
   serviceName: {{ include "elasticsearch.ingest.fullname" . }}-headless
+  podManagementPolicy: Parallel
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -1,19 +1,32 @@
 {{- if .Values.ingest.enabled }}
-apiVersion: {{ template "deployment.apiVersion" . }}
-kind: Deployment
+apiVersion: {{ template "statefulset.apiVersion" . }}
+kind: StatefulSet
 metadata:
   name: {{ include "elasticsearch.ingest.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: ingest
+    app.kubernetes.io/component: ingest
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: ingest
 spec:
+  updateStrategy:
+    type: {{ .Values.ingest.updateStrategy.type }}
+    {{- if (eq "OnDelete" .Values.ingest.updateStrategy.type) }}
+    rollingUpdate: null
+    {{- else if .Values.ingest.updateStrategy.rollingUpdatePartition }}
+    rollingUpdate:
+      partition: {{ .Values.ingest.updateStrategy.rollingUpdatePartition }}
+    {{- end }}
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: ingest
+      app.kubernetes.io/component: ingest
   replicas: {{ .Values.ingest.replicas }}
+  serviceName: {{ include "elasticsearch.ingest.fullname" . }}-headless
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}
-        role: ingest
+        app.kubernetes.io/component: ingest
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: ingest
       {{- with .Values.ingest.podAnnotations }}
       annotations: {{- toYaml . | nindent 10 }}
       {{- end }}
@@ -61,7 +74,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
-              value: {{ template "elasticsearch.discovery.fullname" . }}
+              value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}
             - name: ELASTICSEARCH_PLUGINS
               value: {{ .Values.plugins | quote }}

--- a/bitnami/elasticsearch/templates/ingest-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/ingest-statefulset.yaml
@@ -73,6 +73,8 @@ spec:
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
+            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
+              value: {{ include "elasticsearch.masterHosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             {{- if .Values.plugins }}

--- a/bitnami/elasticsearch/templates/ingest-svc.yaml
+++ b/bitnami/elasticsearch/templates/ingest-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: {{ include "elasticsearch.ingest.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: ingest
+    app.kubernetes.io/component: ingest
   annotations: {{ include "elasticsearch.tplValue" ( dict "value" .Values.ingest.service.annotations "context" $) | nindent 4 }}
 spec:
   type: {{ .Values.ingest.service.type | quote }}
@@ -12,7 +12,7 @@ spec:
   loadBalancerIP: {{ .Values.ingest.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: transport
+    - name: tcp-transport
       port: {{ .Values.ingest.service.port }}
       targetPort: transport
       {{- if and (or (eq .Values.ingest.service.type "NodePort") (eq .Values.ingest.service.type "LoadBalancer")) (not (empty .Values.ingest.service.nodePort)) }}
@@ -21,5 +21,5 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
-    role: ingest
+    app.kubernetes.io/component: ingest
 {{- end }}

--- a/bitnami/elasticsearch/templates/master-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/master-headless-svc.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   type: ClusterIP
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
     - name: tcp-transport
       port: 9300

--- a/bitnami/elasticsearch/templates/master-headless-svc.yaml
+++ b/bitnami/elasticsearch/templates/master-headless-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch.master.fullname" . }}-headless
+  labels: {{- include "elasticsearch.labels" . | nindent 4 }}
+    app.kubernetes.io/component: master
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: tcp-transport
+      port: 9300
+      targetPort: transport
+  selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: master

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -91,6 +91,8 @@ spec:
               value: {{ ternary "true" "false" .Values.image.debug | quote }}
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
+            - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
+              value: {{ include "elasticsearch.masterHosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
               value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS

--- a/bitnami/elasticsearch/templates/master-statefulset.yaml
+++ b/bitnami/elasticsearch/templates/master-statefulset.yaml
@@ -3,7 +3,9 @@ kind: StatefulSet
 metadata:
   name: {{ include "elasticsearch.master.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: master
+    app.kubernetes.io/component: master
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: master
 spec:
   updateStrategy:
     type: {{ .Values.master.updateStrategy.type }}
@@ -12,14 +14,16 @@ spec:
     {{- end }}
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: master
-  serviceName: {{ template "elasticsearch.master.fullname" . }}
+      app.kubernetes.io/component: master
+  serviceName: {{ template "elasticsearch.master.fullname" . }}-headless
   podManagementPolicy: Parallel
   replicas: {{ .Values.master.replicas }}
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}
-        role: master
+        app.kubernetes.io/component: master
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: master
       {{- with .Values.master.podAnnotations }}
       annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -88,7 +92,7 @@ spec:
             - name: ELASTICSEARCH_CLUSTER_NAME
               value: {{ .Values.name | quote }}
             - name: ELASTICSEARCH_CLUSTER_HOSTS
-              value: {{ template "elasticsearch.discovery.fullname" . }}
+              value: {{ include "elasticsearch.hosts" . | quote }}
             - name: ELASTICSEARCH_CLUSTER_MASTER_HOSTS
               {{- $elasticsearchMasterFullname := include "elasticsearch.master.fullname" . }}
               {{- $replicas := int .Values.master.replicas }}

--- a/bitnami/elasticsearch/templates/master-svc.yaml
+++ b/bitnami/elasticsearch/templates/master-svc.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "elasticsearch.master.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: master
+    app.kubernetes.io/component: master
   annotations: {{ include "elasticsearch.tplValue" ( dict "value" .Values.master.service.annotations "context" $) | nindent 4 }}
 spec:
   type: {{ .Values.master.service.type | quote }}
@@ -11,7 +11,7 @@ spec:
   loadBalancerIP: {{ .Values.master.service.loadBalancerIP }}
   {{- end }}
   ports:
-    - name: transport
+    - name: tcp-transport
       port: {{ .Values.master.service.port }}
       targetPort: transport
       {{- if and (or (eq .Values.master.service.type "NodePort") (eq .Values.master.service.type "LoadBalancer")) (not (empty .Values.master.service.nodePort)) }}
@@ -20,4 +20,4 @@ spec:
       nodePort: null
       {{- end }}
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
-    role: master
+    app.kubernetes.io/component: master

--- a/bitnami/elasticsearch/templates/metrics-deploy.yaml
+++ b/bitnami/elasticsearch/templates/metrics-deploy.yaml
@@ -4,16 +4,20 @@ kind: Deployment
 metadata:
   name: {{ include "elasticsearch.metrics.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: metrics
+    app.kubernetes.io/component: metrics
+    ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+    app: metrics
 spec:
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: metrics
+      app.kubernetes.io/component: metrics
   replicas: 1
   template:
     metadata:
       labels: {{- include "elasticsearch.labels" . | nindent 8 }}
-        role: metrics
+        app.kubernetes.io/component: metrics
+        ## Istio Labels: https://istio.io/docs/ops/deployment/requirements/
+        app: metrics
       {{- with .Values.metrics.podAnnotations }}
       annotations: {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/bitnami/elasticsearch/templates/metrics-svc.yaml
+++ b/bitnami/elasticsearch/templates/metrics-svc.yaml
@@ -4,14 +4,14 @@ kind: Service
 metadata:
   name: {{ include "elasticsearch.metrics.fullname" . }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: metrics
+    app.kubernetes.io/component: metrics
   annotations: {{ include "elasticsearch.tplValue" ( dict "value" .Values.metrics.service.annotations "context" $) | nindent 4 }}
 spec:
   type: {{ .Values.metrics.service.type }}
   ports:
-    - name: metrics
+    - name: http-metrics
       port: 9114
       targetPort: metrics
   selector: {{- include "elasticsearch.matchLabels" . | nindent 4 }}
-    role: metrics
+    app.kubernetes.io/component: metrics
 {{- end }}

--- a/bitnami/elasticsearch/templates/servicemonitor.yaml
+++ b/bitnami/elasticsearch/templates/servicemonitor.yaml
@@ -7,14 +7,14 @@ metadata:
   namespace: {{ .Values.metrics.serviceMonitor.namespace }}
   {{- end }}
   labels: {{- include "elasticsearch.labels" . | nindent 4 }}
-    role: metrics
+    app.kubernetes.io/component: metrics
     {{- range $key, $value := .Values.metrics.serviceMonitor.selector }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
   selector:
     matchLabels: {{- include "elasticsearch.matchLabels" . | nindent 6 }}
-      role: metrics
+      app.kubernetes.io/component: metrics
   endpoints:
     - port: metrics
       {{- if .Values.metrics.serviceMonitor.interval }}

--- a/bitnami/elasticsearch/values-production.yaml
+++ b/bitnami/elasticsearch/values-production.yaml
@@ -262,8 +262,8 @@ coordinating:
   ##
   replicas: 2
 
-  ## updateStrategy for ElasticSearch coordinating deployment
-  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  ## updateStrategy for ElasticSearch coordinating statefulset
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
     type: RollingUpdate
@@ -464,6 +464,11 @@ ingest:
   ## Number of ingest node(s) replicas to deploy
   ##
   replicas: 2
+  ## updateStrategy for ElasticSearch ingest statefulset
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    type: RollingUpdate
   heapSize: 128m
   ## Provide annotations for the ingest pods.
   ##

--- a/bitnami/elasticsearch/values.yaml
+++ b/bitnami/elasticsearch/values.yaml
@@ -262,8 +262,8 @@ coordinating:
   ##
   replicas: 2
 
-  ## updateStrategy for ElasticSearch coordinating deployment
-  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  ## updateStrategy for ElasticSearch coordinating statefulset
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
   ##
   updateStrategy:
     type: RollingUpdate
@@ -464,6 +464,11 @@ ingest:
   ## Number of ingest node(s) replicas to deploy
   ##
   replicas: 2
+  ## updateStrategy for ElasticSearch ingest statefulset
+  ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
+  ##
+  updateStrategy:
+    type: RollingUpdate
   heapSize: 128m
   ## Provide annotations for the ingest pods.
   ##


### PR DESCRIPTION
Signed-off-by: Ivan Rizzante <ivan.rizzante@tech.sdb.it>
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

* Use parallel management policy for StatefulSet
* Allow to publish not ready EndPoint's for not Ready pods 

**Benefits**

Allows StatefulSet pods to be started in parallel to form an Elasticsearch cluster.
Allows not Ready EndPoint's to be created on startup.

**Possible drawbacks**

**Applicable issues**
  - fixes #2199

**Additional information**

**Checklist** <!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).
- [X ] Variables are documented in the README.md
- [X ] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)
- [X ] If the chart contains a `values-production.yaml` apart from `values.yaml`, ensure that you implement the changes in both files

:warning: Keep in mind that if you want to make changes to the kubeapps chart, please implement them in the [kubeapps repository](https://github.com/kubeapps/kubeapps/tree/master/chart/kubeapps). This is only a synchronized mirror.
