### PR TITLE
[bitnami/chart] Fix kubeapps chart to use helper for pinniped-proxy full name.

### DIFF
--- a/bitnami/kubeapps/templates/frontend/configmap.yaml
+++ b/bitnami/kubeapps/templates/frontend/configmap.yaml
@@ -89,7 +89,7 @@ data:
     {{- if .certificateAuthorityData }}
         proxy_set_header PINNIPED_PROXY_API_SERVER_CERT {{ .certificateAuthorityData }};
     {{- end }}
-        proxy_pass http://kubeapps-internal-pinniped-proxy.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
+        proxy_pass http://{{ template "kubeapps.pinniped-proxy.fullname" $ }}.{{ $.Release.Namespace }}:{{ $.Values.pinnipedProxy.service.port }};
     {{- else }}
         # Otherwise we route directly through to the clusters with existing credentials.
         proxy_pass {{ $apiServiceBaseURL }};

--- a/bitnami/kubeapps/templates/kubeops/deployment.yaml
+++ b/bitnami/kubeapps/templates/kubeops/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - --clusters-config-path=/config/clusters.conf
             {{- end }}
             {{- if .Values.pinnipedProxy.enabled }}
-            - --pinniped-proxy-url=http://kubeapps-internal-pinniped-proxy.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
+            - --pinniped-proxy-url=http://{{ template "kubeapps.pinniped-proxy.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.pinnipedProxy.service.port }}
             {{- end }}
             {{- if .Values.kubeops.burst }}
             - --burst={{ .Values.kubeops.burst }}


### PR DESCRIPTION
See https://github.com/kubeapps/kubeapps/pull/2768 for original PR against the current repo chart version.

**Checklist** 
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/).

Not done since it's to be merged upstream as part of Juan's change.

- [ ] Variables are documented in the README.md

No changes.

- [X] Title of the PR starts with chart name (e.g. `[bitnami/chart]`)

